### PR TITLE
refactor: rename default genDir to `mocks`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ out-via-ir
 out/*/*
 
 # Ignore generated mock contracts
-solidity/test/mock-contracts/
+solidity/test/mocks/
 
 # mac
 **/.DS_Store

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Option      | Default                           | Notes
 ------------|-----------------------------------|-------
 `contracts` | —                                 | The path to the solidity contracts to mock
 `out`       | `./out`                           | The path that has the compiled artifacts
-`genDir`    | `./solidity/test/mocks`           | The path to the generated mock contracts
+`mocks `    | `./solidity/test/mocks`           | The path to the generated mock contracts
 `ignore`    | []                                | A list of directories to ignore, e.g. `--ignore libraries`
 
 ### Using mocks

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Option      | Default                           | Notes
 ------------|-----------------------------------|-------
 `contracts` | —                                 | The path to the solidity contracts to mock
 `out`       | `./out`                           | The path that has the compiled artifacts
-`genDir`    | `./solidity/test/mock-contracts`  | The path to the generated mock contracts
+`genDir`    | `./solidity/test/mocks`           | The path to the generated mock contracts
 `ignore`    | []                                | A list of directories to ignore, e.g. `--ignore libraries`
 
 ### Using mocks
@@ -75,8 +75,8 @@ The next step would be importing the mock contract in your unit tests, deploying
 ```solidity
 import 'forge-std/Test.sol';
 
-import { MockGreeter } from '/path/to/mock-contracts/MockGreeter.sol';
-import { MockHelper } from '/path/to/mock-contracts/MockHelper.sol';
+import { MockGreeter } from '/path/to/mocks/MockGreeter.sol';
+import { MockHelper } from '/path/to/mocks/MockHelper.sol';
 
 contract BaseTest is Test, MockHelpers {
   MockGreeter public greeter;
@@ -113,8 +113,8 @@ greeter.set__greeting('Holá');
 - If you have a contract named `Helper`, you can avoid the name collision like so:
 
 ```solidity
-import { MockHelper } from '/path/to/mock-contracts/contracts/MockHelper.sol';
-import { MockHelper as FoundryMockHelper } from '/path/to/mock-contracts/MockHelper.sol';
+import { MockHelper } from '/path/to/mocks/contracts/MockHelper.sol';
+import { MockHelper as FoundryMockHelper } from '/path/to/mocks/MockHelper.sol';
 
 contract BaseTest is Test, FoundryMockHelper {
   // You get the idea

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ The next step would be importing the mock contract in your unit tests, deploying
 ```solidity
 import 'forge-std/Test.sol';
 
-import { MockGreeter } from '/path/to/mocks/MockGreeter.sol';
+import { MockGreeter } from '/path/to/mocks/contracts/MockGreeter.sol';
 import { MockHelper } from '/path/to/mocks/MockHelper.sol';
 
-contract BaseTest is Test, MockHelpers {
+contract BaseTest is Test, MockHelper {
   MockGreeter public greeter;
 
   function setUp() public {
@@ -113,7 +113,6 @@ greeter.set__greeting('Holá');
 - If you have a contract named `Helper`, you can avoid the name collision like so:
 
 ```solidity
-import { MockHelper } from '/path/to/mocks/contracts/MockHelper.sol';
 import { MockHelper as FoundryMockHelper } from '/path/to/mocks/MockHelper.sol';
 
 contract BaseTest is Test, FoundryMockHelper {

--- a/solidity/test/ContractTest.t.sol
+++ b/solidity/test/ContractTest.t.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
 import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
-import {MockContractTest} from 'test/mock-contracts/contracts/MockContractTest.sol';
+import {MockContractTest} from 'test/mocks/contracts/MockContractTest.sol';
 import {console} from 'forge-std/console.sol';
-import {MockHelper} from 'test/mock-contracts/MockHelper.sol';
+import {MockHelper} from 'test/mocks/MockHelper.sol';
 
 contract CommonE2EBase is Test, MockHelper {
   uint256 internal constant _FORK_BLOCK = 15_452_788;

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,8 +5,8 @@ import { hideBin } from 'yargs/helpers';
 import { generateMockContracts } from './index';
 
 (async () => {
-  const { contracts, out, genDir, ignore } = getProcessArguments();
-  generateMockContracts(contracts, out, genDir, ignore);
+  const { contracts, out, mocks, ignore } = getProcessArguments();
+  generateMockContracts(contracts, out, mocks, ignore);
 })();
 
 function getProcessArguments() {
@@ -23,7 +23,7 @@ function getProcessArguments() {
         default: './out',
         type: 'string',
       },
-      genDir: {
+      mocks: {
         describe: `Generated contracts directory`,
         default: './solidity/test/mocks',
         type: 'string',

--- a/src/run.ts
+++ b/src/run.ts
@@ -25,7 +25,7 @@ function getProcessArguments() {
       },
       genDir: {
         describe: `Generated contracts directory`,
-        default: './solidity/test/mock-contracts',
+        default: './solidity/test/mocks',
         type: 'string',
       },
       ignore: {

--- a/test/e2e/get-external-functions.spec.ts
+++ b/test/e2e/get-external-functions.spec.ts
@@ -12,7 +12,7 @@ describe('E2E: getExternalMockFunctions', () => {
     // generate mock contracts
     const contractsDir = ['solidity/contracts', 'solidity/interfaces'];
     const compiledArtifactsDir = 'out';
-    const generatedContractsDir = 'solidity/test/mock-contracts';
+    const generatedContractsDir = 'solidity/test/mocks';
     const ignoreDir = [];
     await generateMockContracts(contractsDir, compiledArtifactsDir, generatedContractsDir, ignoreDir);
 

--- a/test/e2e/get-internal-functions.spec.ts
+++ b/test/e2e/get-internal-functions.spec.ts
@@ -12,7 +12,7 @@ describe('E2E: getInternalMockFunctions', () => {
     // generate mock contracts
     const contractsDir = ['solidity/contracts', 'solidity/interfaces'];
     const compiledArtifactsDir = 'out';
-    const generatedContractsDir = 'solidity/test/mock-contracts';
+    const generatedContractsDir = 'solidity/test/mocks';
     const ignoreDir = [];
     await generateMockContracts(contractsDir, compiledArtifactsDir, generatedContractsDir, ignoreDir);
 

--- a/test/e2e/set-variables.spec.ts
+++ b/test/e2e/set-variables.spec.ts
@@ -9,7 +9,7 @@ describe('E2E: getStateVariables', () => {
     // generate mock contracts
     const contractsDir = ['solidity/contracts', 'solidity/interfaces'];
     const compiledArtifactsDir = 'out';
-    const generatedContractsDir = 'solidity/test/mock-contracts';
+    const generatedContractsDir = 'solidity/test/mocks';
     const ignoreDir = [];
     await generateMockContracts(contractsDir, compiledArtifactsDir, generatedContractsDir, ignoreDir);
 


### PR DESCRIPTION
Closes BES-117, BES-122