### PR TITLE
build: remove `solidity-utils` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
-    "@defi-wonderland/solidity-utils": "0.0.0-4298c6c6",
     "handlebars": "4.7.7",
     "prettier": "^3.0.3",
     "yargs": "17.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,15 +398,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@defi-wonderland/solidity-utils@0.0.0-4298c6c6":
-  version "0.0.0-4298c6c6"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/solidity-utils/-/solidity-utils-0.0.0-4298c6c6.tgz#4ac9e4bcc586f7434715357310a7a3c30e81f17f"
-  integrity sha512-jpecgVx9hpnXXGnYnN8ayd1ONj4ljk0hI36ltNfkNwlDkLLzPt4/FY5YSyY/628Exfuy5X9Rl9gGv5UtYgAmtw==
-  dependencies:
-    "@openzeppelin/contracts" "4.8.1"
-    ds-test "https://github.com/dapphub/ds-test"
-    forge-std "https://github.com/foundry-rs/forge-std"
-
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -518,11 +509,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
-
-"@openzeppelin/contracts@4.8.1":
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.1.tgz#709cfc4bbb3ca9f4460d60101f15dac6b7a2d5e4"
-  integrity sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ==
 
 "@sinonjs/commons@^2.0.0":
   version "2.0.0"
@@ -1403,10 +1389,6 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
-"ds-test@https://github.com/dapphub/ds-test":
-  version "1.0.0"
-  resolved "https://github.com/dapphub/ds-test#e282159d5170298eb2455a6c05280ab5a73a4ef0"
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1762,10 +1744,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-"forge-std@https://github.com/foundry-rs/forge-std":
-  version "1.5.6"
-  resolved "https://github.com/foundry-rs/forge-std#e8a047e3f40f13fa37af6fe14e6e06283d9a060e"
 
 fs-extra@^11.0.0:
   version "11.1.1"


### PR DESCRIPTION
Closes BES-126