### PR TITLE
feat: change default mocks directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ out-via-ir
 out/*/*
 
 # Ignore generated mock contracts
-solidity/test/mocks/
+solidity/test/smock/
 
 # mac
 **/.DS_Store

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Option      | Default                           | Notes
 ------------|-----------------------------------|-------
 `contracts` | —                                 | The path to the solidity contracts to mock
 `out`       | `./out`                           | The path that has the compiled artifacts
-`mocks `    | `./solidity/test/mocks`           | The path to the generated mock contracts
+`mocks `    | `./solidity/test/smock`           | The path to the generated mock contracts
 `ignore`    | []                                | A list of directories to ignore, e.g. `--ignore libraries`
 
 ### Using mocks
@@ -75,8 +75,8 @@ The next step would be importing the mock contract in your unit tests, deploying
 ```solidity
 import 'forge-std/Test.sol';
 
-import { MockGreeter } from '/path/to/mocks/contracts/MockGreeter.sol';
-import { SmockHelper } from '/path/to/mocks/SmockHelper.sol';
+import { MockGreeter } from '/path/to/smock/contracts/MockGreeter.sol';
+import { SmockHelper } from '/path/to/smock/SmockHelper.sol';
 
 contract BaseTest is Test, SmockHelper {
   MockGreeter public greeter;

--- a/solidity/test/ContractTest.t.sol
+++ b/solidity/test/ContractTest.t.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 import {Test} from 'forge-std/Test.sol';
 import {IERC20} from 'isolmate/interfaces/tokens/IERC20.sol';
-import {MockContractTest, IContractTest} from 'test/mocks/contracts/MockContractTest.sol';
+import {MockContractTest, IContractTest} from 'test/smock/contracts/MockContractTest.sol';
 import {console} from 'forge-std/console.sol';
-import {SmockHelper} from 'test/mocks/SmockHelper.sol';
+import {SmockHelper} from 'test/smock/SmockHelper.sol';
 
 contract CommonE2EBase is Test, SmockHelper {
   uint256 internal constant _FORK_BLOCK = 15_452_788;

--- a/src/run.ts
+++ b/src/run.ts
@@ -25,7 +25,7 @@ function getProcessArguments() {
       },
       mocks: {
         describe: `Generated contracts directory`,
-        default: './solidity/test/mocks',
+        default: './solidity/test/smock',
         type: 'string',
       },
       ignore: {

--- a/test/e2e/get-external-functions.spec.ts
+++ b/test/e2e/get-external-functions.spec.ts
@@ -12,7 +12,7 @@ describe('E2E: getExternalMockFunctions', () => {
     // generate mock contracts
     const contractsDir = ['solidity/contracts', 'solidity/interfaces'];
     const compiledArtifactsDir = 'out';
-    const generatedContractsDir = 'solidity/test/mocks';
+    const generatedContractsDir = 'solidity/test/smock';
     const ignoreDir = [];
     await generateMockContracts(contractsDir, compiledArtifactsDir, generatedContractsDir, ignoreDir);
 

--- a/test/e2e/get-internal-functions.spec.ts
+++ b/test/e2e/get-internal-functions.spec.ts
@@ -12,7 +12,7 @@ describe('E2E: getInternalMockFunctions', () => {
     // generate mock contracts
     const contractsDir = ['solidity/contracts', 'solidity/interfaces'];
     const compiledArtifactsDir = 'out';
-    const generatedContractsDir = 'solidity/test/mocks';
+    const generatedContractsDir = 'solidity/test/smock';
     const ignoreDir = [];
     await generateMockContracts(contractsDir, compiledArtifactsDir, generatedContractsDir, ignoreDir);
 

--- a/test/e2e/set-variables.spec.ts
+++ b/test/e2e/set-variables.spec.ts
@@ -9,7 +9,7 @@ describe('E2E: getStateVariables', () => {
     // generate mock contracts
     const contractsDir = ['solidity/contracts', 'solidity/interfaces'];
     const compiledArtifactsDir = 'out';
-    const generatedContractsDir = 'solidity/test/mocks';
+    const generatedContractsDir = 'solidity/test/smock';
     const ignoreDir = [];
     await generateMockContracts(contractsDir, compiledArtifactsDir, generatedContractsDir, ignoreDir);
 


### PR DESCRIPTION
We've realized some projects may have their own mocks defined in the `mocks` directory. Also there is a cooler name!