### PR TITLE
fix: correctly mock functions without returned values

### DIFF
--- a/solidity/contracts/utils/ContractAbstract.sol
+++ b/solidity/contracts/utils/ContractAbstract.sol
@@ -13,4 +13,5 @@ abstract contract ContractAbstract {
   }
 
   function undefinedFunc(string memory _someText) public virtual returns (bool _result);
+  function undefinedFuncNoReturn(string memory _someText) public virtual;
 }

--- a/solidity/contracts/utils/ContractB.sol
+++ b/solidity/contracts/utils/ContractB.sol
@@ -9,4 +9,8 @@ contract ContractB is IContractB {
     stringVariable = _stringVariable;
     _result = true;
   }
+
+  function _internalNoReturn() internal {
+    stringVariable = 'internalNoReturn';
+  }
 }

--- a/src/templates/mockExternalFunctionTemplate.hbs
+++ b/src/templates/mockExternalFunctionTemplate.hbs
@@ -1,9 +1,9 @@
 {{#if isInterface}}
-function {{functionName}}({{inputString}}) external{{stateMutabilityString}}returns ({{outputString}}) {}
+function {{functionName}}({{inputString}}) external{{stateMutabilityString}}{{#if outputString}}returns ({{outputString}}){{/if}} {}
 
 {{/if}}
 {{#if abstractAndVirtual}}
-function {{functionName}}({{inputString}}) {{visibility}}{{stateMutabilityString}}override returns ({{outputString}}) {}
+function {{functionName}}({{inputString}}) {{visibility}}{{stateMutabilityString}}override {{#if outputString}}returns ({{outputString}}){{/if}} {}
 
 {{/if}}
 function mock_call_{{functionName}}({{arguments}}) public {

--- a/src/templates/mockInternalFunctionTemplate.hbs
+++ b/src/templates/mockInternalFunctionTemplate.hbs
@@ -6,7 +6,7 @@ function mock_call_{{functionName}}({{arguments}}) public {
   );
 }
 
-function {{functionName}}({{inputsString}}) internal override returns ({{outputsString}}) {
+function {{functionName}}({{inputsString}}) internal override {{#if outputsString}}returns ({{outputsString}}){{/if}} {
     (bool _success, bytes memory _data) = address(this).call(abi.encodeWithSignature("{{signature}}", {{inputsStringNames}}));
     ({{outputsStringNames}}) = _success ? abi.decode(_data, ({{outputsTypesString}})) : super.{{functionName}}({{inputsStringNames}});
 }


### PR DESCRIPTION
Given a function that does not return anything, the generator produces mock functions such as:
```solidity
function someFunction() external override returns () {}
```

Not the empty `returns` at the end of the function declaration.