### PR TITLE
feat: sync Github and NPM releases

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -12,8 +12,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
+          registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
         run: yarn build
 
       - name: Publish
-        run: npm publish --access public
+        run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
+          registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
         run: yarn build
 
       - name: Publish
-        run: yarn npm publish --access public --tag latest
+        run: yarn publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
         run: yarn build
 
       - name: Publish
-        run: yarn npm publish --access public
+        run: yarn npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR includes a few changes
- using the new setup-node action
- configuring the release action to be triggered every time there is a Github release
- tagging the production releases as `latest`