### PR TITLE
docs: deploy correct contract in usage tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ contract BaseTest is Test, SmockHelper {
     // return _greeterAddress;
 
     greeter = MockGreeter(
-      deployMock('Greeter', type(Greeter).creationCode, abi.encode('Hello'))
+      deployMock('Greeter', type(MockGreeter).creationCode, abi.encode('Hello'))
     );
   }
 }


### PR DESCRIPTION
If a user were to copy-paste the previous version of the edited snippet, they'd get bare reverts when calling a mock method, since said snippet deploys the Greeter's (not MockGreeter) bytecode, which doesn't handle them and reverts on unkown function selectors
